### PR TITLE
Debian support for role

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ None
 | `dovecot_group` | Group name of `dovecot` | `{{ __dovecot_group }}` |
 | `dovecot_service` | Service name of `dovecot` | `{{ __dovecot_service }}` |
 | `dovecot_package` | Package name of `dovecot` | `{{ __dovecot_package }}` |
+| `dovecot_packages_extra` | Extra packages to install (Debian only) | `[]` |
 | `dovecot_conf_dir` | Path to directory where `dovecot.conf` resides | `{{ __dovecot_conf_dir }}` |
 | `dovecot_confd_dir` | Path to `conf.d` | `{{ dovecot_conf_dir }}/conf.d` |
 | `dovecot_conf_file` | Path to `dovecot.conf(5)` | `{{ __dovecot_conf_dir }}/dovecot.conf` |
@@ -69,6 +70,18 @@ dovecot:\
   :openfiles-max=2048:\
   :tc=daemon:
 ```
+
+## Debian
+
+| Variable | Default |
+|----------|---------|
+| `__dovecot_user` | `dovecot` |
+| `__dovecot_group` | `dovecot` |
+| `__dovecot_conf_dir` | `/etc/dovecot` |
+| `__dovecot_service` | `dovecot` |
+| `__dovecot_package` | `dovecot-core` |
+| `__dovecot_base_dir` | `/var/run/dovecot` |
+| `__dovecot_login_class` | `""` |
 
 ## TLS/SSL support
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@ dovecot_user: "{{ __dovecot_user }}"
 dovecot_group: "{{ __dovecot_group }}"
 dovecot_service: "{{ __dovecot_service }}"
 dovecot_package: "{{ __dovecot_package }}"
+dovecot_packages_extra: []
 dovecot_conf_dir: "{{ __dovecot_conf_dir }}"
 dovecot_confd_dir: "{{ dovecot_conf_dir }}/conf.d"
 dovecot_conf_file: "{{ __dovecot_conf_dir }}/dovecot.conf"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -8,19 +8,15 @@ galaxy_info:
   platforms:
   - name: FreeBSD
     versions:
-    - 10.3
+      - 10.3
   - name: OpenBSD
     versions:
-    - 6.1
-    - 6.2
-#  - name: Ubuntu
-#    versions:
-#    - trusty
-#    - xenial
-#  - name: EL
-#    versions:
-#    - 7
-
+      - 6.1
+      - 6.2
+  - name: Debian
+    versions:
+      - 8
+      - 9
   galaxy_tags:
     - imap
     - pop3

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -3,3 +3,9 @@
   apt:
     name: "{{ dovecot_package }}"
     state: present
+
+- name: Install additional packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ dovecot_packages_extra }}"

--- a/tasks/install-Debian.yml
+++ b/tasks/install-Debian.yml
@@ -1,0 +1,5 @@
+---
+- name: Install dovecot package
+  apt:
+    name: "{{ dovecot_package }}"
+    state: present

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,7 +33,7 @@
     state: directory
 
 - name: Include x509_certificate
-  import_role:
+  include_role:
     name: trombik.x509-certificate
   when: dovecot_include_role_x509_certificate
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 # tasks file for ansible-role-dovecot
 
-- include_vars: "{{ ansible_os_family }}.yml"
+- name: Include OS-specific variables
+  include_vars: "{{ ansible_os_family }}.yml"
 
 - name: Assert dovecot_config_fragments has valid items
   assert:
@@ -12,7 +13,8 @@
       - item.name | length > 0
   with_items: "{{ dovecot_config_fragments }}"
 
-- include_tasks: "install-{{ ansible_os_family }}.yml"
+- name: Include OS-specific installation
+  include_tasks: "install-{{ ansible_os_family }}.yml"
 
 - name: Add dovecot user to dovecot_extra_groups
   user:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,6 +2,6 @@ __dovecot_user: dovecot
 __dovecot_group: dovecot
 __dovecot_conf_dir: /etc/dovecot
 __dovecot_service: dovecot
-__dovecot_package: dovecot
+__dovecot_package: dovecot-core
 __dovecot_base_dir: /var/run/dovecot
 __dovecot_login_class: ""

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,7 @@
+__dovecot_user: dovecot
+__dovecot_group: dovecot
+__dovecot_conf_dir: /etc/dovecot
+__dovecot_service: dovecot
+__dovecot_package: dovecot
+__dovecot_base_dir: /var/run/dovecot
+__dovecot_login_class: ""


### PR DESCRIPTION
This includes support for installing the role on Debian, aside from *BSD.

Defaults and appropriate tasks have been added; also, `dovecot_packages_extra` is used to install extra packages as Debian splits up services into several packages.