### PR TITLE
Do not create dovecot home directory

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
     name: "{{ dovecot_user }}"
     append: yes
     groups: "{{ dovecot_extra_groups }}"
+    create_home: no
 
 - name: Create conf directory
   file:


### PR DESCRIPTION
The task “Add dovecot user to dovecot_extra_groups” is implicitly creating dovecot home directory which is not desired. For example on OpenBSD it lead to the creation of /nonexistant, a directory that should definitely not exists.