### PR TITLE
Do not call openbsd_pkg in a loop

### DIFF
--- a/tasks/install-OpenBSD.yml
+++ b/tasks/install-OpenBSD.yml
@@ -13,9 +13,8 @@
 
 - name: Install additional dovecot packages
   openbsd_pkg:
-    name: "{{ item }}"
+    name: "{{ dovecot_extra_packages }}"
     state: present
-  with_items: "{{ dovecot_extra_packages }}"
 
 - name: Create login.conf(5) entry for dovecot user
   # see /usr/local/share/doc/pkg-readmes/dovecot-*


### PR DESCRIPTION
Essentially prevent ansible from cluttering the console with warnings.